### PR TITLE
Remove placeholder for Danish PPD Identifier (Identifier type not in …

### DIFF
--- a/input/profiles/StructureDefinition-PackagedProductDefinition.xml
+++ b/input/profiles/StructureDefinition-PackagedProductDefinition.xml
@@ -25,17 +25,6 @@
             </slicing>
         </element>
 
-        <!-- Danish national PackagedProductDefinition identifier -->
-        <!-- TODO
-        <element id="PackagedProductDefinition.identifier:danishPpdId">
-            <path value="PackagedProductDefinition.identifier"/>
-            <sliceName value="danishPpdId"/>
-        </element>
-        <element id="PackagedProductDefinition.identifier:danishPpdId.system">
-            <path value="PackagedProductDefinition.identifier.system"/>
-            <patternUri value="http://"/>
-        </element>
-        -->
         <!-- Danish definition of Nordic Article Number -->
         <element id="PackagedProductDefinition.identifier:danishVnr">
             <path value="PackagedProductDefinition.identifier"/>


### PR DESCRIPTION
Removing the placeholder since there is no Identifier system on the example PPDs apart from the varenummer.
@cjjdlidk @PeterMadsenDLI 